### PR TITLE
chore(readme): remove old 3 ads per page warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ page loads.
 
 
 ## Caveats:
-- **Note:** AdSense limits you to a maximum of three (3) ads per page.
 - **Caution:** Reloading of ads arbitrarily (with minimal page content changes) may result in
 the suspension of your AdSense account. _Refer to AdSense for full terms of use._
 - Google needs to crawl each page where ads appear. Ensure your site SSR renders any page where


### PR DESCRIPTION
### Related Issue

#175 

### Notes

I checked the official Google documentation for reference just in case, but as the specifications for the previously stated restrictions have simply disappeared, there still does not seem to be a page that explicitly states that there are no restrictions.