### PR TITLE
fix: access public runtime config warning

### DIFF
--- a/src/runtime/components-v3/Adsbygoogle.vue
+++ b/src/runtime/components-v3/Adsbygoogle.vue
@@ -63,7 +63,7 @@ export default {
   },
   computed: {
     options () {
-      const options = { ...useRuntimeConfig()['google-adsense'] || {} }
+      const options = { ...useRuntimeConfig().public['google-adsense'] || {} }
       if (options.test) {
         options.id = 'ca-google'
       }
@@ -76,7 +76,7 @@ export default {
   watch: {
     '$route' (to, from) {
       // Update if element is connected to DOM.
-      // Prevent updating not connected alive componentns.
+      // Prevent updating not connected alive components.
       if (this.$el && !this.$el.isConnected) {
         return
       }


### PR DESCRIPTION
This fixes the following warning from nuxt

```
[nuxt] [runtimeConfig] You are trying to access a public runtime config value (google-adsense) directly from the top level. This currently works (for backward compatibility with Nuxt 2) but this compatibility layer will be removed in v3.5. Instead, you can update config['google-adsense'] to config.public['google-adsense'].
```

Fixes #173 