### PR TITLE
fix: unnecessary withDefaults

### DIFF
--- a/src/runtime/components/Adsbygoogle.vue
+++ b/src/runtime/components/Adsbygoogle.vue
@@ -6,11 +6,17 @@ import type { AdFormats } from '../../module'
 
 const {
   adClient,
+  adFullWidthResponsive = false,
+  adLayout = null,
+  adLayoutKey = null,
+  adSlot = null,
+  adStyle = { display: 'block' },
   analyticsDomainName,
   analyticsUacct,
   hideUnfilled,
   includeQuery,
-} = withDefaults(defineProps<{
+  pageUrl = null,
+} = defineProps<{
   adClient?: string
   adSlot?: string | null
   adFormat?: AdFormats | string
@@ -23,17 +29,7 @@ const {
   analyticsUacct?: string
   analyticsDomainName?: string
   includeQuery?: boolean
-}>(),
-{
-  adFullWidthResponsive: false,
-  adLayout: null,
-  adLayoutKey: null,
-  pageUrl: null,
-  adSlot: null,
-  adStyle: () => ({ display: 'block' }),
-  adClient: undefined,
-  hideUnfilled: undefined,
-  })
+}>()
 
 
 const {


### PR DESCRIPTION
Component errors when upgrading to `Nuxt 3.7.4`. This pr removes the unnecessary `withDefaults` function from the `Adsbygoogle` component. 

@manniL Hope the weeks going well. Is this the best way to let you know about pr's?