### PR TITLE
fix: do not select ins element inserted by Google and raising a adsbygoogle.push() error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ export function initializeAdClient(options: ModuleOptions) {
   return createScriptMeta(
     `adsbygoogle.onload = function() {
       adsbygoogle.pauseAdRequests=${options.pauseOnLoad ? '1' : '0'};
-      [].forEach.call(document.getElementsByClassName('adsbygoogle'), function() { adsbygoogle.push(${adsenseScript}); })
+      [].forEach.call(document.querySelectorAll("ins.adsbygoogle[data-ad-client='${options.id}']"), function() { adsbygoogle.push(${adsenseScript}); })
     };`)
 }
 


### PR DESCRIPTION
It seems that Adsense script automatically insert an invisible ins element at the bottom of the page
'''
<ins class="adsbygoogle adsbygoogle-noablate" style="display: none !important;" data-adsbygoogle-status="done" data-ad-status="unfilled"><div id="aswift_0_host" style="border: medium; height: 0px; width: 0px; margin: 0px; padding: 0px; position: relative; visibility: visible; background-color: transparent; display: inline-block;" tabindex="0" title="Advertisement" aria-label="Advertisement"><iframe ...></iframe></div></ins>
'''

So if we don't put any ads component on a page, the current onload script will find this ins (with className 'adsbygoogle') and try to call adsbygoogle.push with raises the error "All ins elements in the DOM with class=adsbygoogle already have ads in them."
I think this pull request fixes #156 and maybe #179 
Also it works only when onPageLoad option is set to true.