### PR TITLE
fix: do not use protocol-relative URL

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -20,7 +20,7 @@ export interface ModuleOptions {
 }
 
 // AdSense script URL
-const ADSENSE_URL = '//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js'
+const ADSENSE_URL = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js'
 // Default client ID for testing
 const TEST_ID = 'ca-google'
 


### PR DESCRIPTION
A protocol-relative URL has multiple downsides, most notably security and performance-wise. 
This PR changes it to use the fully qualified https: protocol
More information:
https://webhint.io/docs/user-guide/hints/hint-no-protocol-relative-urls/