### PR TITLE
fix: prevent occuring of TagError: adsbygoogle.push() error: All ins elements in the DOM with class=adsbygoogle already have ads in them. (https://github.com/nuxt-modules/google-adsense/issues/179)

### DIFF
--- a/src/runtime/composables/adsense.ts
+++ b/src/runtime/composables/adsense.ts
@@ -78,7 +78,12 @@ export function useAdsense(input: UseAdsenseOptions) {
       return
 
     try {
-      (window.adsbygoogle = window.adsbygoogle || []).push({})
+      window.adsbygoogle = window.adsbygoogle || [];
+      
+      if (window.adsbygoogle.hasOwnProperty("loaded") && 
+        (window.adsbygoogle as any).loaded === false) {
+        window.adsbygoogle.push({});
+      }
     }
     catch (error) {
       console.error(error)


### PR DESCRIPTION
### 🔗 Linked issue

[Issue #179](https://github.com/nuxt-modules/google-adsense/issues/179)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Added check to prevent calling `.push({})` more then once on `window.adsbygoogle` object. Described error in the linked issue is happening only when for some reason push method is called more than once.

P.S. I'm not really familiar with Vue.js/Nuxt and for this reason unit test is not included in the PR. This fixed the problem for me in my NextJS project and I decided to contribute. I hope this fix the issue for you guys too.
